### PR TITLE
Read API credentials from config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ Java Maven project that fetches the top 20 USDC pairs from Binance and generates
 
 ## Build
 
+Create a `src/main/resources/config.properties` file with your Binance API credentials before packaging:
+
+```
+api.key=YOUR_API_KEY
+api.secret=YOUR_SECRET_KEY
+```
+
+Then package the project:
+
 ```bash
 mvn package
 ```

--- a/src/main/java/com/example/BotOrchestrator.java
+++ b/src/main/java/com/example/BotOrchestrator.java
@@ -48,6 +48,10 @@ public class BotOrchestrator {
         }
         String apiKey = props.getProperty("api.key");
         String secretKey = props.getProperty("api.secret");
+        if (apiKey == null || secretKey == null) {
+            throw new IllegalStateException("API credentials missing in config.properties");
+        }
+        logger.info("Loaded API credentials from config.properties");
         SpotClient client = new SpotClientImpl(apiKey, secretKey);
         // Fetch all 24hr tickers
         String tickersJson = client.createMarket().ticker24H(new LinkedHashMap<>());

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -1,0 +1,2 @@
+api.key=YOUR_API_KEY_HERE
+api.secret=YOUR_SECRET_KEY_HERE


### PR DESCRIPTION
## Summary
- Load API credentials from a `config.properties` resource with validation and logging
- Document configuration step and packaging process
- Provide example `config.properties` for API key and secret

## Testing
- `mvn -q package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6890d3ed4c2c8320b3f305d00396a7b8